### PR TITLE
Bump Avalonia to 0.10.4

### DIFF
--- a/VtNetCore.Avalonia.App/VtNetCore.Avalonia.App.csproj
+++ b/VtNetCore.Avalonia.App/VtNetCore.Avalonia.App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">
@@ -18,9 +18,9 @@
     <None Remove="Models\**" />
   </ItemGroup>  
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.9.10" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.10" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.10" />
+    <PackageReference Include="Avalonia" Version="0.10.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.4" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VtNetCore.Avalonia\VtNetCore.Avalonia.csproj" />

--- a/VtNetCore.Avalonia/VtNetCore.Avalonia.csproj
+++ b/VtNetCore.Avalonia/VtNetCore.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia" Version="0.10.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Working on a currently private repo(will be public when it works), found this and my repo uses newest version of Avalonia.